### PR TITLE
1.22 nvdec mem

### DIFF
--- a/subprojects/gst-plugins-bad/gst-libs/gst/codecs/gstav1decoder.c
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/codecs/gstav1decoder.c
@@ -409,7 +409,8 @@ gst_av1_decoder_process_sequence (GstAV1Decoder * self, GstAV1OBU * obu)
   }
 
   ret = klass->new_sequence (self, &seq_header,
-      GST_AV1_TOTAL_REFS_PER_FRAME + priv->preferred_output_delay);
+      /* +1 for the current frame */
+      GST_AV1_TOTAL_REFS_PER_FRAME + 1 + priv->preferred_output_delay);
   if (ret != GST_FLOW_OK) {
     GST_ERROR_OBJECT (self, "subclass does not want accept new sequence");
     return ret;

--- a/subprojects/gst-plugins-bad/gst-libs/gst/codecs/gsth265decoder.c
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/codecs/gsth265decoder.c
@@ -424,23 +424,68 @@ gst_h265_decoder_set_latency (GstH265Decoder * self, const GstH265SPS * sps,
   gst_video_decoder_set_latency (GST_VIDEO_DECODER (self), min, max);
 }
 
-static GstFlowReturn
-gst_h265_decoder_process_sps (GstH265Decoder * self, GstH265SPS * sps)
+typedef struct
 {
-  GstH265DecoderPrivate *priv = self->priv;
-  gint max_dpb_size;
-  gint prev_max_dpb_size;
-  gint MaxLumaPS;
-  const gint MaxDpbPicBuf = 6;
-  gint PicSizeInSamplesY;
-  guint8 field_seq_flag = 0;
-  guint8 progressive_source_flag = 0;
-  guint8 interlaced_source_flag = 0;
-  GstFlowReturn ret = GST_FLOW_OK;
+  const gchar *level_name;
+  guint8 level_idc;
+  guint32 MaxLumaPs;
+} GstH265LevelLimits;
 
-  /* A.4.1 */
-  MaxLumaPS = 35651584;
+/* *INDENT-OFF* */
+/* Table A.8 - General tier and level limits */
+static const GstH265LevelLimits level_limits[] = {
+  /* level    idc   MaxLumaPs */
+  {  "1",     30,    36864    },
+  {  "2",     60,    122880   },
+  {  "2.1",   63,    245760   },
+  {  "3",     90,    552960   },
+  {  "3.1",   93,    983040   },
+  {  "4",     120,   2228224  },
+  {  "4.1",   123,   2228224  },
+  {  "5",     150,   8912896  },
+  {  "5.1",   153,   8912896  },
+  {  "5.2",   156,   8912896  },
+  {  "6",     180,   35651584 },
+  {  "6.1",   183,   35651584 },
+  {  "6.2",   186,   35651584 },
+};
+/* *INDENT-ON* */
+
+static gint
+gst_h265_decoder_get_max_dpb_size_from_sps (GstH265Decoder * self,
+    GstH265SPS * sps)
+{
+  guint i;
+  guint PicSizeInSamplesY;
+  /* Default is the worst case level 6.2 */
+  guint32 MaxLumaPS = G_MAXUINT32;
+  const gint MaxDpbPicBuf = 6;
+  gint max_dpb_size;
+
+  /* Unknown level */
+  if (sps->profile_tier_level.level_idc == 0)
+    return 16;
+
   PicSizeInSamplesY = sps->width * sps->height;
+  for (i = 0; i < G_N_ELEMENTS (level_limits); i++) {
+    if (sps->profile_tier_level.level_idc <= level_limits[i].level_idc) {
+      if (PicSizeInSamplesY <= level_limits[i].MaxLumaPs) {
+        MaxLumaPS = level_limits[i].MaxLumaPs;
+      } else {
+        GST_DEBUG_OBJECT (self,
+            "%u (%dx%d) exceeds allowed max luma sample for level \"%s\" %u",
+            PicSizeInSamplesY, sps->width, sps->height,
+            level_limits[i].level_name, level_limits[i].MaxLumaPs);
+      }
+      break;
+    }
+  }
+
+  /* Unknown level */
+  if (MaxLumaPS == G_MAXUINT32)
+    return 16;
+
+  /* A.4.2 */
   if (PicSizeInSamplesY <= (MaxLumaPS >> 2))
     max_dpb_size = MaxDpbPicBuf * 4;
   else if (PicSizeInSamplesY <= (MaxLumaPS >> 1))
@@ -450,7 +495,21 @@ gst_h265_decoder_process_sps (GstH265Decoder * self, GstH265SPS * sps)
   else
     max_dpb_size = MaxDpbPicBuf;
 
-  max_dpb_size = MIN (max_dpb_size, 16);
+  return MIN (max_dpb_size, 16);
+}
+
+static GstFlowReturn
+gst_h265_decoder_process_sps (GstH265Decoder * self, GstH265SPS * sps)
+{
+  GstH265DecoderPrivate *priv = self->priv;
+  gint max_dpb_size;
+  gint prev_max_dpb_size;
+  guint8 field_seq_flag = 0;
+  guint8 progressive_source_flag = 0;
+  guint8 interlaced_source_flag = 0;
+  GstFlowReturn ret = GST_FLOW_OK;
+
+  max_dpb_size = gst_h265_decoder_get_max_dpb_size_from_sps (self, sps);
 
   if (sps->vui_parameters_present_flag)
     field_seq_flag = sps->vui_params.field_seq_flag;

--- a/subprojects/gst-plugins-bad/gst-libs/gst/codecs/gstmpeg2decoder.c
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/codecs/gstmpeg2decoder.c
@@ -802,8 +802,8 @@ gst_mpeg2_decoder_handle_picture (GstMpeg2Decoder * decoder,
         &priv->seq_display_ext : NULL,
         _seq_scalable_ext_is_valid (&priv->seq_scalable_ext) ?
         &priv->seq_scalable_ext : NULL,
-        /* previous/next 2 pictures */
-        2 + priv->preferred_output_delay);
+        /* previous/next 2 pictures + current picture */
+        3 + priv->preferred_output_delay);
 
     if (ret != GST_FLOW_OK) {
       GST_WARNING_OBJECT (decoder, "new sequence error");

--- a/subprojects/gst-plugins-bad/gst-libs/gst/codecs/gstvp8decoder.c
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/codecs/gstvp8decoder.c
@@ -193,8 +193,8 @@ gst_vp8_decoder_check_codec_change (GstVp8Decoder * self,
     g_assert (klass->new_sequence);
 
     ret = klass->new_sequence (self, frame_hdr,
-        /* last/golden/alt 3 pictures */
-        3 + priv->preferred_output_delay);
+        /* last/golden/alt 3 reference pictures + current picture */
+        4 + priv->preferred_output_delay);
   }
 
   return ret;

--- a/subprojects/gst-plugins-bad/gst-libs/gst/codecs/gstvp9decoder.c
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/codecs/gstvp9decoder.c
@@ -251,7 +251,8 @@ gst_vp9_decoder_check_codec_change (GstVp9Decoder * self,
   }
 
   ret = klass->new_sequence (self, frame_hdr,
-      GST_VP9_REF_FRAMES + priv->preferred_output_delay);
+      /* +1 for the current frame */
+      GST_VP9_REF_FRAMES + 1 + priv->preferred_output_delay);
 
   if (ret != GST_FLOW_OK)
     priv->had_sequence = FALSE;

--- a/subprojects/gst-plugins-bad/sys/nvcodec/gstnvdecoder.c
+++ b/subprojects/gst-plugins-bad/sys/nvcodec/gstnvdecoder.c
@@ -278,8 +278,9 @@ gst_nv_decoder_configure (GstNvDecoder * decoder, cudaVideoCodec codec,
 
   format = GST_VIDEO_INFO_FORMAT (info);
 
-  /* Additional 2 frame margin */
-  pool_size += 2;
+  /* h264 may require additional 1 frame because of its bumping process */
+  if (codec == cudaVideoCodec_H264)
+    pool_size += 1;
 
   /* Need pool size * 2 for decode-only (used for reference) frame
    * and output frame, AV1 film grain case for example */


### PR DESCRIPTION
- Changes to reduce GPU memory usage of stateless decoder.
- See details: [slack](https://coramai.slack.com/archives/C03BS2W7GQN/p1691594540609019?thread_ts=1691444469.591739&cid=C03BS2W7GQN)