### PR TITLE
cudaipc: Implement async stop

### DIFF
--- a/subprojects/gst-plugins-bad/sys/nvcodec/gstcudaipcclient_c.h
+++ b/subprojects/gst-plugins-bad/sys/nvcodec/gstcudaipcclient_c.h
@@ -1,0 +1,29 @@
+/* GStreamer
+ * Copyright (C) 2023 Seungha Yang <seungha@centricular.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include <gst/gst.h>
+
+G_BEGIN_DECLS
+
+void gst_cuda_ipc_client_deinit (void);
+
+G_END_DECLS
+

--- a/subprojects/gst-plugins-bad/sys/nvcodec/plugin.c
+++ b/subprojects/gst-plugins-bad/sys/nvcodec/plugin.c
@@ -51,6 +51,7 @@
 #include "gstnvh265encoder.h"
 #include "gstcudaipcsink.h"
 #include "gstcudaipcsrc.h"
+#include "gstcudaipcclient_c.h"
 
 GST_DEBUG_CATEGORY (gst_nvcodec_debug);
 GST_DEBUG_CATEGORY (gst_nvdec_debug);
@@ -63,6 +64,13 @@ GST_DEBUG_CATEGORY (gst_cuda_nvmm_debug);
 #endif
 
 #define GST_CAT_DEFAULT gst_nvcodec_debug
+
+
+static void
+plugin_deinit (gpointer data)
+{
+  gst_cuda_ipc_client_deinit ();
+}
 
 static gboolean
 plugin_init (GstPlugin * plugin)
@@ -323,6 +331,10 @@ plugin_init (GstPlugin * plugin)
     GST_INFO ("Enable NVMM support");
   }
 #endif
+
+  g_object_set_data_full (G_OBJECT (plugin),
+      "plugin-nvcodec-shutdown", (gpointer) "shutdown-data",
+      (GDestroyNotify) plugin_deinit);
 
   return TRUE;
 }


### PR DESCRIPTION
In case of import mode, downstream might hold the memory and release later. cudaipcsrc should not be blocked on that situation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/orcamobility/gstreamer/4)
<!-- Reviewable:end -->
