### PR TITLE
cudaipcclient: Protect shared_ptr of GstCudaIpcImportData with global…

### DIFF
--- a/subprojects/gst-plugins-bad/sys/nvcodec/gstcudaipcsrc.cpp
+++ b/subprojects/gst-plugins-bad/sys/nvcodec/gstcudaipcsrc.cpp
@@ -402,6 +402,8 @@ gst_cuda_ipc_src_unlock (GstBaseSrc * src)
   if (priv->client)
     gst_cuda_ipc_client_set_flushing (priv->client, true);
 
+  GST_DEBUG_OBJECT (self, "Unlocked");
+
   return TRUE;
 }
 
@@ -417,6 +419,8 @@ gst_cuda_ipc_src_unlock_stop (GstBaseSrc * src)
   priv->flushing = false;
   if (priv->client)
     gst_cuda_ipc_client_set_flushing (priv->client, false);
+
+  GST_DEBUG_OBJECT (self, "Unlock stopped");
 
   return TRUE;
 }


### PR DESCRIPTION
… lock

Releasing shared_ptr of GstCudaIpcImportData makes corresponding weak_ptr in the global IPC handle table invalid but actual destructor could be called later. Then the global IPC handle table might try to import the IPC handle which is still opened.
Thus, we should protect the shared_ptr with global lock as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/orcamobility/gstreamer/7)
<!-- Reviewable:end -->
