### PR TITLE
nvcodec: Pass CUDA_ERROR_NO_DEVICE 

### DIFF
--- a/subprojects/gst-plugins-bad/gst-libs/gst/cuda/stub/cuda.h
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/cuda/stub/cuda.h
@@ -39,6 +39,7 @@ typedef gint CUdevice;
 typedef enum
 {
   CUDA_SUCCESS = 0,
+  CUDA_ERROR_NO_DEVICE = 100,
   CUDA_ERROR_ALREADY_MAPPED = 208,
 } CUresult;
 

--- a/subprojects/gst-plugins-bad/sys/nvcodec/gstnvbaseenc.c
+++ b/subprojects/gst-plugins-bad/sys/nvcodec/gstnvbaseenc.c
@@ -460,7 +460,13 @@ gst_nv_base_enc_open_encode_session (GstNvBaseEnc * nvenc)
   params.deviceType = NV_ENC_DEVICE_TYPE_CUDA;
   nv_ret = NvEncOpenEncodeSessionEx (&params, &nvenc->encoder);
 
-  return nv_ret == NV_ENC_SUCCESS;
+  if (nv_ret != NV_ENC_SUCCESS) {
+    /* Report error to abort if GST_CUDA_CRITICAL_ERRORS is configured */
+    gst_cuda_result (CUDA_ERROR_NO_DEVICE);
+    return FALSE;
+  }
+
+  return TRUE;
 }
 
 static gboolean

--- a/subprojects/gst-plugins-bad/sys/nvcodec/plugin.c
+++ b/subprojects/gst-plugins-bad/sys/nvcodec/plugin.c
@@ -129,6 +129,10 @@ plugin_init (GstPlugin * plugin)
     CuGetErrorString (cuda_ret, &err_desc);
     GST_ERROR ("Failed to init cuda, cuInit ret: 0x%x: %s: %s",
         (int) cuda_ret, err_name, err_desc);
+
+    /* to abort if GST_CUDA_CRITICAL_ERRORS is configured */
+    gst_cuda_result (CUDA_ERROR_NO_DEVICE);
+
     return TRUE;
   }
 


### PR DESCRIPTION
### Summary
nvcodec: Pass CUDA_ERROR_NO_DEVICE to gst_cuda_result() on error so that application can be terminated if
"GST_CUDA_CRITICAL_ERRORS=100" env is configured (100 = CUDA_ERROR_NO_DEVICE)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/orcamobility/gstreamer/8)
<!-- Reviewable:end -->
