### PR TITLE
update gst-plugins-rs sha

### DIFF
--- a/subprojects/gst-plugins-rs.wrap
+++ b/subprojects/gst-plugins-rs.wrap
@@ -2,4 +2,4 @@
 directory=gst-plugins-rs
 url=https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git
 push-url=git@gitlab.freedesktop.org:gstreamer/gst-plugins-rs.git
-revision=0.9
+revision=0.11.1+fixup


### PR DESCRIPTION
Change the revision of wrap file of gst-plugins-rs to use the latest release s.t. we can build awskvswebrtcsink , the tags are from https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/tags

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/orcamobility/gstreamer/9)
<!-- Reviewable:end -->
