### PR TITLE
cudaipcsink: Fix deadlock on stop

### DIFF
--- a/subprojects/gst-plugins-bad/sys/nvcodec/gstcudaipcserver.cpp
+++ b/subprojects/gst-plugins-bad/sys/nvcodec/gstcudaipcserver.cpp
@@ -502,13 +502,27 @@ gst_cuda_ipc_server_on_idle (GstCudaIpcServer * server)
 
     GST_DEBUG_OBJECT (server, "Have %" G_GSIZE_FORMAT " alive connections",
         priv->conn_map.size());
+
+    size_t num_closed = 0;
     for (auto it : priv->conn_map) {
       auto conn = it.second;
       GST_DEBUG_OBJECT (server, "conn-id %u"
           " peer handle size %" G_GSIZE_FORMAT, conn->id,
           conn->peer_handles.size ());
+
+      /* Cannot erase conn since it's still referenced.
+       * Manually close connection */
+      if (conn->peer_handles.empty ()) {
+        conn->CloseConn ();
+        num_closed++;
+      }
     }
     /* *INDENT-ON* */
+
+    if (priv->conn_map.size () == num_closed) {
+      GST_DEBUG_OBJECT (server, "All connections were closed");
+      klass->terminate (server);
+    }
 
     return;
   }

--- a/subprojects/gst-plugins-bad/sys/nvcodec/gstcudaipcserver.h
+++ b/subprojects/gst-plugins-bad/sys/nvcodec/gstcudaipcserver.h
@@ -129,6 +129,8 @@ struct GstCudaIpcServerConn : public OVERLAPPED
     gst_clear_caps (&caps);
   }
 
+  virtual void CloseConn () = 0;
+
   GstCudaIpcServer *server;
 
   GstCudaContext *context = nullptr;

--- a/subprojects/gst-plugins-bad/sys/nvcodec/gstcudaipcserver_unix.cpp
+++ b/subprojects/gst-plugins-bad/sys/nvcodec/gstcudaipcserver_unix.cpp
@@ -47,8 +47,14 @@ struct GstCudaIpcServerConnUnix : public GstCudaIpcServerConn
     g_clear_object (&socket_conn);
   }
 
+  void CloseConn ()
+  {
+    if (socket_conn)
+      g_io_stream_close (G_IO_STREAM (socket_conn), nullptr, nullptr);
+  }
+
   /* Holds ref */
-  GSocketConnection *socket_conn;
+  GSocketConnection *socket_conn = nullptr;
 
   /* Owned by socket_conn */
   GInputStream *istream;

--- a/subprojects/gst-plugins-bad/sys/nvcodec/gstcudaipcserver_win32.cpp
+++ b/subprojects/gst-plugins-bad/sys/nvcodec/gstcudaipcserver_win32.cpp
@@ -42,14 +42,20 @@ struct GstCudaIpcServerConnWin32 : public GstCudaIpcServerConn
 
   virtual ~GstCudaIpcServerConnWin32 ()
   {
+    CloseConn ();
+  }
+
+  void CloseConn ()
+  {
     if (pipe != INVALID_HANDLE_VALUE) {
       CancelIo (pipe);
       DisconnectNamedPipe (pipe);
       CloseHandle (pipe);
+      pipe = INVALID_HANDLE_VALUE;
     }
   }
 
-  HANDLE pipe;
+  HANDLE pipe = INVALID_HANDLE_VALUE;
 };
 
 struct GstCudaIpcServerWin32Private


### PR DESCRIPTION
Manually close connection if client does not hold any shared memory on stop.