### PR TITLE
Revert h264parse au enhance

### DIFF
--- a/subprojects/gst-plugins-bad/gst-libs/gst/codecparsers/gsth264parser.h
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/codecparsers/gsth264parser.h
@@ -141,8 +141,6 @@ typedef enum {
  * @GST_H264_NAL_PREFIX_UNIT: Prefix NAL unit
  * @GST_H264_NAL_SUBSET_SPS: Subset sequence parameter set (SSPS) NAL unit
  * @GST_H264_NAL_DEPTH_SPS: Depth parameter set (DPS) NAL unit
- * @GST_H264_NAL_RSV_1: First reserved parameter
- * @GST_H264_NAL_RSV_2: Second reserved parameter
  * @GST_H264_NAL_SLICE_AUX: Auxiliary coded picture without partitioning NAL unit
  * @GST_H264_NAL_SLICE_EXT: Coded slice extension NAL unit
  * @GST_H264_NAL_SLICE_DEPTH: Coded slice extension for depth or 3D-AVC texture view
@@ -168,24 +166,6 @@ typedef enum
   GST_H264_NAL_PREFIX_UNIT  = 14,
   GST_H264_NAL_SUBSET_SPS   = 15,
   GST_H264_NAL_DEPTH_SPS    = 16,
-
-  /**
-   * GST_H264_NAL_RSV_1:
-   *
-   * First reserved parameter
-   *
-   * Since: 1.24
-   */
-  GST_H264_NAL_RSV_1        = 17,
-
-  /**
-   * GST_H264_NAL_RSV_2:
-   *
-   * Second reserved parameter
-   *
-   * Since: 1.24
-   */
-  GST_H264_NAL_RSV_2        = 18,
   GST_H264_NAL_SLICE_AUX    = 19,
   GST_H264_NAL_SLICE_EXT    = 20,
   GST_H264_NAL_SLICE_DEPTH  = 21

--- a/subprojects/gst-plugins-bad/gst/videoparsers/gsth264parse.c
+++ b/subprojects/gst-plugins-bad/gst/videoparsers/gsth264parse.c
@@ -1129,6 +1129,10 @@ gst_h264_parse_process_nal (GstH264Parse * h264parse, GstH264NalUnit * nalu)
       h264parse->header = TRUE;
       break;
     case GST_H264_NAL_SEI:
+      /* expected state: got-sps */
+      if (!GST_H264_PARSE_STATE_VALID (h264parse, GST_H264_PARSE_STATE_GOT_SPS))
+        return FALSE;
+
       h264parse->header = TRUE;
       gst_h264_parse_process_sei (h264parse, nalu);
       /* mark SEI pos */

--- a/subprojects/gst-plugins-bad/gst/videoparsers/gsth264parse.c
+++ b/subprojects/gst-plugins-bad/gst/videoparsers/gsth264parse.c
@@ -1699,11 +1699,11 @@ gst_h264_parse_process_backlog_loop (GstH264Parse * h264parse,
 
 static gboolean
 gst_h264_parse_process_backlog_nal (GstH264Parse * h264parse, gint * proc_size,
-    gboolean * aud_insert, guint8 * data, gboolean drain, gboolean au_completed)
+    gboolean * aud_insert, guint8 * data, gboolean clear_bl,
+    gboolean au_completed)
 {
   GstH264NalUnit *bnalu;
   gint framesize = 0;
-  gboolean next_is_aud = FALSE;
 
   g_assert (h264parse->nal_backlog != NULL);
   g_assert (h264parse->nal_backlog->len > 0);
@@ -1733,19 +1733,14 @@ gst_h264_parse_process_backlog_nal (GstH264Parse * h264parse, gint * proc_size,
     gst_h264_parse_trim_backlog (h264parse);
   }
 
-  if (h264parse->bl_next_nal < h264parse->nal_backlog->len) {
-    bnalu = &g_array_index (h264parse->nal_backlog, GstH264NalUnit,
-        h264parse->bl_next_nal);
-    next_is_aud = bnalu->type == GST_H264_NAL_AU_DELIMITER;
+  /* Process all backlog. Used when draining or output in NAL mode. */
+  if (!gst_h264_parse_process_backlog_loop (h264parse,
+          h264parse->nal_backlog->len, TRUE, aud_insert, data, &framesize)) {
+    goto fail;
   }
 
-  /* Process all backlog. Used when draining or in NAL mode and nals still
-   * in backlog after completing or next is AUD. */
-  if ((au_completed || drain || next_is_aud)) {
-    if (!gst_h264_parse_process_backlog_loop (h264parse,
-            h264parse->nal_backlog->len, TRUE, aud_insert, data, &framesize)) {
-      goto fail;
-    }
+  if (clear_bl) {
+    gst_h264_parse_clear_backlog (h264parse);
   }
 
   /* Backlog content doesn't need to parsed again, adjust offset accordingly. */
@@ -2032,7 +2027,7 @@ gst_h264_parse_handle_frame (GstBaseParse * parse,
 
     if (h264parse->align == GST_H264_PARSE_ALIGN_NAL) {
       if (!gst_h264_parse_process_backlog_nal (h264parse, &framesize,
-              &h264parse->aud_insert, data, drain,
+              &h264parse->aud_insert, data, FALSE,
               blstatus == GST_H264_PARSE_BACKLOG_STATUS_AU_COMPLETE)) {
         *skipsize = current_off;
       }

--- a/subprojects/gst-plugins-bad/gst/videoparsers/gsth264parse.c
+++ b/subprojects/gst-plugins-bad/gst/videoparsers/gsth264parse.c
@@ -1671,8 +1671,8 @@ gst_h264_parse_clear_backlog (GstH264Parse * h264parse)
 
 static gboolean
 gst_h264_parse_process_backlog_loop (GstH264Parse * h264parse,
-    gint curr_next_thresh, gboolean adjust_offset_for_next,
-    gboolean * aud_insert, guint8 * data, gint * framesize)
+    gint curr_next_thresh, gboolean * aud_insert, guint8 * data,
+    gint * framesize)
 {
   GstH264NalUnit *bnalu;
   gint i, size = 0;
@@ -1690,7 +1690,7 @@ gst_h264_parse_process_backlog_loop (GstH264Parse * h264parse,
 
       size = bnalu->offset + bnalu->size;
       h264parse->bl_next_nal = i + 1;
-    } else if (adjust_offset_for_next) {
+    } else {
       /* section of backlog that belong to next AU */
       bnalu->offset -= size;
       bnalu->sc_offset -= size;
@@ -1726,11 +1726,10 @@ gst_h264_parse_process_backlog_nal (GstH264Parse * h264parse, gint * proc_size,
    * insert a AUD. If the first nal from next AU is a AUD we don't need to wait
    * the completion the first vcl from next AU, AUD is the start of next AU.
    */
-  if (!gst_h264_parse_process_backlog_loop (h264parse,
-          h264parse->bl_next_au_first_nal, FALSE, aud_insert, data,
-          &framesize)) {
+  if (gst_h264_parse_process_backlog_loop (h264parse,
+          h264parse->bl_next_au_first_nal, aud_insert, data,
+          &framesize) == FALSE)
     goto fail;
-  }
 
   /* We've processed a complete AU */
   if (au_completed) {
@@ -1738,10 +1737,9 @@ gst_h264_parse_process_backlog_nal (GstH264Parse * h264parse, gint * proc_size,
   }
 
   /* Process all backlog. Used when draining or output in NAL mode. */
-  if (!gst_h264_parse_process_backlog_loop (h264parse,
-          h264parse->nal_backlog->len, TRUE, aud_insert, data, &framesize)) {
+  if (gst_h264_parse_process_backlog_loop (h264parse,
+          h264parse->nal_backlog->len, aud_insert, data, &framesize) == FALSE)
     goto fail;
-  }
 
   if (clear_bl) {
     gst_h264_parse_clear_backlog (h264parse);
@@ -1774,11 +1772,10 @@ gst_h264_parse_process_backlog (GstH264Parse * h264parse, gint * proc_size,
       h264parse->nal_backlog->len - 1);
   h264parse->current_off = bnalu->offset + bnalu->size;
 
-  if (!gst_h264_parse_process_backlog_loop (h264parse,
-          h264parse->bl_next_au_first_nal, !proc_nau, aud_insert, data,
-          &framesize)) {
+  if (gst_h264_parse_process_backlog_loop (h264parse,
+          h264parse->bl_next_au_first_nal, aud_insert, data,
+          &framesize) == FALSE)
     goto fail;
-  }
 
   /* We've processed a complete AU */
   if (h264parse->bl_next_au_first_nal < h264parse->nal_backlog->len) {
@@ -1787,16 +1784,9 @@ gst_h264_parse_process_backlog (GstH264Parse * h264parse, gint * proc_size,
 
   /* Process all backlog. Used when draining or output in NAL mode. */
   if (proc_nau) {
-    gint drain_size = 0;
-    if (!gst_h264_parse_process_backlog_loop (h264parse,
-            h264parse->nal_backlog->len, TRUE, aud_insert, data, &drain_size)) {
+    if (gst_h264_parse_process_backlog_loop (h264parse,
+            h264parse->nal_backlog->len, aud_insert, data, &framesize) == FALSE)
       goto fail;
-    }
-
-    /* returned size is pointing the byte position of the last nalu end.
-     * do not accumulate but replace with last nalu position */
-    if (drain_size > 0)
-      framesize = drain_size;
   }
 
   if (clear_bl) {

--- a/subprojects/gst-plugins-bad/gst/videoparsers/gsth264parse.c
+++ b/subprojects/gst-plugins-bad/gst/videoparsers/gsth264parse.c
@@ -40,9 +40,6 @@ GST_DEBUG_CATEGORY (h264_parse_debug);
 #define DEFAULT_CONFIG_INTERVAL      (0)
 #define DEFAULT_UPDATE_TIMECODE       FALSE
 
-#define HIST_IDX_CURR                 0
-#define HIST_IDX_PREV                 1
-
 enum
 {
   PROP_0,
@@ -84,14 +81,6 @@ enum
   GST_H264_PARSE_SEI_ACTIVE = 1,
   GST_H264_PARSE_SEI_PARSED = 2,
 };
-
-typedef enum
-{
-  GST_H264_PARSE_BACKLOG_STATUS_AU_INCOMPLETE = 0,
-  GST_H264_PARSE_BACKLOG_STATUS_AU_COMPLETE,
-  GST_H264_PARSE_BACKLOG_STATUS_UPD_FAILED,
-  GST_H264_PARSE_BACKLOG_STATUS_NOT_SUPPORTED
-} GstH264ParseBacklogStatus;
 
 #define GST_H264_PARSE_STATE_VALID(parse, expected_state) \
   (((parse)->state & (expected_state)) == (expected_state))
@@ -138,9 +127,6 @@ static gboolean gst_h264_parse_src_event (GstBaseParse * parse,
     GstEvent * event);
 static void gst_h264_parse_update_src_caps (GstH264Parse * h264parse,
     GstCaps * caps);
-
-static GstH264ParseBacklogStatus gst_h264_parse_update_backlog (GstH264Parse *
-    h264parse, GstH264NalUnit * nalu);
 
 static void
 gst_h264_parse_class_init (GstH264ParseClass * klass)
@@ -219,14 +205,6 @@ gst_h264_parse_init (GstH264Parse * h264parse)
   h264parse->aud_needed = TRUE;
   h264parse->aud_insert = TRUE;
   h264parse->update_timecode = DEFAULT_UPDATE_TIMECODE;
-  h264parse->nal_backlog = g_array_new (FALSE, FALSE, sizeof (GstH264NalUnit));
-  h264parse->bl_curr_au_last_vcl = -1;
-  h264parse->bl_next_au_first_vcl = 1;
-  h264parse->bl_next_au_first_nal = 1;
-  h264parse->bl_next_nal = 0;
-
-  h264parse->history_slice[HIST_IDX_CURR].valid = FALSE;
-  h264parse->history_slice[HIST_IDX_PREV].valid = FALSE;
 }
 
 static void
@@ -237,7 +215,6 @@ gst_h264_parse_finalize (GObject * object)
   gst_video_user_data_unregistered_clear (&h264parse->user_data_unregistered);
 
   g_object_unref (h264parse->frame_out);
-  g_array_unref (h264parse->nal_backlog);
 
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }
@@ -246,6 +223,9 @@ static void
 gst_h264_parse_reset_frame (GstH264Parse * h264parse)
 {
   GST_DEBUG_OBJECT (h264parse, "reset frame");
+
+  /* done parsing; reset state */
+  h264parse->current_off = -1;
 
   h264parse->update_caps = FALSE;
   h264parse->idr_pos = -1;
@@ -331,7 +311,6 @@ gst_h264_parse_reset (GstH264Parse * h264parse)
   h264parse->discard_bidirectional = FALSE;
   h264parse->marker = FALSE;
 
-  g_array_set_size (h264parse->nal_backlog, 0);
   gst_h264_parse_reset_stream_info (h264parse);
 }
 
@@ -353,7 +332,6 @@ gst_h264_parse_start (GstBaseParse * parse)
   h264parse->field_pic_flag = 0;
   h264parse->aud_needed = TRUE;
   h264parse->aud_insert = FALSE;
-  h264parse->current_off = -1;
 
   gst_base_parse_set_min_frame_size (parse, 4);
 
@@ -970,66 +948,6 @@ gst_h264_parse_process_sei (GstH264Parse * h264parse, GstH264NalUnit * nalu)
   g_array_free (messages, TRUE);
 }
 
-static void
-gst_h264_parse_update_vcl_nal_history_sps (GstH264Parse * h264parse,
-    GstH264SPS * sps)
-{
-  h264parse->history_sps[HIST_IDX_PREV] = h264parse->history_sps[HIST_IDX_CURR];
-  h264parse->history_sps[HIST_IDX_CURR].pic_order_cnt_type =
-      sps->pic_order_cnt_type;
-  h264parse->history_sps[HIST_IDX_CURR].profile_idc = sps->profile_idc;
-}
-
-static void
-gst_h264_parse_update_vcl_nal_history_pps (GstH264Parse * h264parse,
-    GstH264PPS * pps)
-{
-  gst_h264_parse_update_vcl_nal_history_sps (h264parse, pps->sequence);
-  h264parse->history_pps[HIST_IDX_PREV] = h264parse->history_pps[HIST_IDX_CURR];
-  h264parse->history_pps[HIST_IDX_CURR].id = pps->id;
-}
-
-static void
-gst_h264_parse_update_vcl_nal_history_nalu (GstH264Parse * h264parse,
-    GstH264NalUnit * nalu)
-{
-  h264parse->history_nalu[HIST_IDX_PREV]
-      = h264parse->history_nalu[HIST_IDX_CURR];
-  h264parse->history_nalu[HIST_IDX_CURR].ref_idc = nalu->ref_idc;
-  h264parse->history_nalu[HIST_IDX_CURR].idr_pic_flag = nalu->idr_pic_flag;
-
-  if (GST_H264_IS_MVC_NALU (nalu))
-    h264parse->history_nalu[HIST_IDX_CURR].view_id =
-        nalu->extension.mvc.view_id;
-}
-
-static void
-gst_h264_parse_update_vcl_nal_history (GstH264Parse * h264parse,
-    GstH264NalUnit * nalu, GstH264SliceHdr * slice)
-{
-  gst_h264_parse_update_vcl_nal_history_nalu (h264parse, nalu);
-  gst_h264_parse_update_vcl_nal_history_pps (h264parse, slice->pps);
-  h264parse->history_slice[HIST_IDX_PREV]
-      = h264parse->history_slice[HIST_IDX_CURR];
-  h264parse->history_slice[HIST_IDX_CURR].valid = TRUE;
-  h264parse->history_slice[HIST_IDX_CURR].frame_num = slice->frame_num;
-  h264parse->history_slice[HIST_IDX_CURR].field_pic_flag
-      = slice->field_pic_flag;
-  h264parse->history_slice[HIST_IDX_CURR].bottom_field_flag
-      = slice->bottom_field_flag;
-  h264parse->history_slice[HIST_IDX_CURR].idr_pic_id = slice->idr_pic_id;
-  h264parse->history_slice[HIST_IDX_CURR].delta_pic_order_cnt[0]
-      = slice->delta_pic_order_cnt[0];
-  h264parse->history_slice[HIST_IDX_CURR].delta_pic_order_cnt[1]
-      = slice->delta_pic_order_cnt[1];
-  h264parse->history_slice[HIST_IDX_CURR].pic_order_cnt_lsb
-      = slice->pic_order_cnt_lsb;
-  h264parse->history_slice[HIST_IDX_CURR].delta_pic_order_cnt_bottom
-      = slice->delta_pic_order_cnt_bottom;
-  h264parse->history_slice[HIST_IDX_CURR].first_mb_in_slice
-      = slice->first_mb_in_slice;
-}
-
 /* caller guarantees 2 bytes of nal payload */
 static gboolean
 gst_h264_parse_process_nal (GstH264Parse * h264parse, GstH264NalUnit * nalu)
@@ -1261,6 +1179,44 @@ gst_h264_parse_process_nal (GstH264Parse * h264parse, GstH264NalUnit * nalu)
   return TRUE;
 }
 
+/* caller guarantees at least 2 bytes of nal payload for each nal
+ * returns TRUE if next_nal indicates that nal terminates an AU */
+static inline gboolean
+gst_h264_parse_collect_nal (GstH264Parse * h264parse, GstH264NalUnit * nalu)
+{
+  GstH264NalUnitType nal_type = nalu->type;
+  gboolean complete;
+
+  /* determine if AU complete */
+  GST_LOG_OBJECT (h264parse, "next nal type: %d %s (picture started %i)",
+      nal_type, _nal_name (nal_type), h264parse->picture_start);
+
+  /* consider a coded slices (IDR or not) to start a picture,
+   * (so ending the previous one) if first_mb_in_slice == 0
+   * (non-0 is part of previous one) */
+  /* NOTE this is not entirely according to Access Unit specs in 7.4.1.2.4,
+   * but in practice it works in sane cases, needs not much parsing,
+   * and also works with broken frame_num in NAL
+   * (where spec-wise would fail) */
+  complete = h264parse->picture_start && ((nal_type >= GST_H264_NAL_SEI &&
+          nal_type <= GST_H264_NAL_AU_DELIMITER) ||
+      (nal_type >= 14 && nal_type <= 18));
+
+  /* first_mb_in_slice == 0 considered start of frame */
+  if (nalu->size > nalu->header_bytes)
+    complete |= h264parse->picture_start && (nal_type == GST_H264_NAL_SLICE
+        || nal_type == GST_H264_NAL_SLICE_DPA
+        || nal_type == GST_H264_NAL_SLICE_IDR) &&
+        (nalu->data[nalu->offset + nalu->header_bytes] & 0x80);
+
+  GST_LOG_OBJECT (h264parse, "au complete: %d", complete);
+
+  if (complete)
+    h264parse->picture_start = FALSE;
+
+  return complete;
+}
+
 static guint8 au_delim[6] = {
   0x00, 0x00, 0x00, 0x01,       /* nal prefix */
   0x09,                         /* nal unit type = access unit delimiter */
@@ -1377,426 +1333,6 @@ gst_h264_parse_handle_frame_packetized (GstBaseParse * parse,
   return ret;
 }
 
-static gboolean
-gst_h264_parse_received_first_vcl_nal_base (GstH264Parse * h264parse,
-    GstH264ParseHistorySlice * slice_hdr_prev)
-{
-  /* Ref. ITU-T H.264, 7.4.1.2.4 */
-  GstH264ParseHistorySlice *slice_hdr_curr
-      = &h264parse->history_slice[HIST_IDX_CURR];
-  GstH264ParseHistoryPPS *pps_hist_curr
-      = &h264parse->history_pps[HIST_IDX_CURR];
-  GstH264ParseHistoryPPS *pps_hist_prev
-      = &h264parse->history_pps[HIST_IDX_PREV];
-  GstH264ParseHistorySPS *sps_hist_curr
-      = &h264parse->history_sps[HIST_IDX_CURR];
-  GstH264ParseHistorySPS *sps_hist_prev
-      = &h264parse->history_sps[HIST_IDX_PREV];
-  GstH264ParseHistoryNalUnit *nalu_hist_curr
-      = &h264parse->history_nalu[HIST_IDX_CURR];
-  GstH264ParseHistoryNalUnit *nalu_hist_prev
-      = &h264parse->history_nalu[HIST_IDX_PREV];
-
-  if (slice_hdr_curr->frame_num != slice_hdr_prev->frame_num) {
-    return TRUE;
-  } else if (pps_hist_curr->id != pps_hist_prev->id) {
-    return TRUE;
-  } else if (slice_hdr_curr->field_pic_flag != slice_hdr_prev->field_pic_flag) {
-    return TRUE;
-  } else if (slice_hdr_curr->field_pic_flag
-      && (slice_hdr_curr->bottom_field_flag
-          != slice_hdr_prev->bottom_field_flag)) {
-    return TRUE;
-  } else if ((nalu_hist_curr->ref_idc == 0 || nalu_hist_prev->ref_idc == 0)
-      && nalu_hist_curr->ref_idc != nalu_hist_prev->ref_idc) {
-    return TRUE;
-  } else if (sps_hist_curr->pic_order_cnt_type == 0
-      && sps_hist_prev->pic_order_cnt_type == 0
-      && (slice_hdr_curr->pic_order_cnt_lsb
-          != slice_hdr_prev->pic_order_cnt_lsb
-          || slice_hdr_curr->delta_pic_order_cnt_bottom
-          != slice_hdr_prev->delta_pic_order_cnt_bottom)) {
-    return TRUE;
-  } else if (sps_hist_curr->pic_order_cnt_type == 1
-      && sps_hist_prev->pic_order_cnt_type == 1
-      && (slice_hdr_curr->delta_pic_order_cnt[0]
-          != slice_hdr_prev->delta_pic_order_cnt[0]
-          || slice_hdr_curr->delta_pic_order_cnt[1]
-          != slice_hdr_prev->delta_pic_order_cnt[1])) {
-    return TRUE;
-  } else if (nalu_hist_curr->idr_pic_flag != nalu_hist_prev->idr_pic_flag) {
-    return TRUE;
-  } else if (nalu_hist_curr->idr_pic_flag == 1
-      && nalu_hist_prev->idr_pic_flag == 1
-      && (slice_hdr_curr->idr_pic_id != slice_hdr_prev->idr_pic_id)) {
-    return TRUE;
-  } else if (slice_hdr_curr->first_mb_in_slice
-      <= slice_hdr_prev->first_mb_in_slice) {
-    return TRUE;
-  }
-  return FALSE;
-}
-
-static gboolean
-gst_h264_parse_received_first_vcl_nal_mvc (GstH264Parse * h264parse,
-    GstH264ParseHistorySlice * slice_hdr_prev)
-{
-  /* Ref. ITU-T H.264, H.7.4.1.2.4 */
-  GstH264ParseHistoryNalUnit *nalu_hist_curr
-      = &h264parse->history_nalu[HIST_IDX_CURR];
-  GstH264ParseHistoryNalUnit *nalu_hist_prev
-      = &h264parse->history_nalu[HIST_IDX_PREV];
-
-  if (nalu_hist_curr->view_id != nalu_hist_prev->view_id)
-    return TRUE;
-
-  return gst_h264_parse_received_first_vcl_nal_base (h264parse, slice_hdr_prev);
-}
-
-static gboolean
-gst_h264_parse_received_first_vcl_nal (GstH264Parse * h264parse)
-{
-  GstH264ParseHistorySlice *slice_hdr_prev
-      = &h264parse->history_slice[HIST_IDX_PREV];
-  GstH264ParseHistorySPS *sps_hist_prev
-      = &h264parse->history_sps[HIST_IDX_PREV];
-
-  if (slice_hdr_prev->valid) {
-    switch (sps_hist_prev->profile_idc) {
-      case GST_H264_PROFILE_BASELINE:
-      case GST_H264_PROFILE_MAIN:
-      case GST_H264_PROFILE_EXTENDED:
-      case GST_H264_PROFILE_HIGH:
-      case GST_H264_PROFILE_HIGH10:
-      case GST_H264_PROFILE_HIGH_422:
-      case GST_H264_PROFILE_HIGH_444:
-        return gst_h264_parse_received_first_vcl_nal_base (h264parse,
-            slice_hdr_prev);
-      case GST_H264_PROFILE_MULTIVIEW_HIGH:
-      case GST_H264_PROFILE_STEREO_HIGH:
-        return gst_h264_parse_received_first_vcl_nal_mvc (h264parse,
-            slice_hdr_prev);
-      case GST_H264_PROFILE_SCALABLE_BASELINE:
-      case GST_H264_PROFILE_SCALABLE_HIGH:
-        /* SVC not supported, should not be reached */
-        g_return_val_if_reached (FALSE);
-      default:
-        return FALSE;
-    }
-    return gst_h264_parse_received_first_vcl_nal_base (h264parse,
-        slice_hdr_prev);
-  }
-  return FALSE;
-}
-
-static gboolean
-is_potential_nonvcl_au_limit (GstH264NalUnit * nalu)
-{
-  gboolean ret = FALSE;
-  switch (nalu->type) {
-    case GST_H264_NAL_AU_DELIMITER:
-    case GST_H264_NAL_SPS:
-    case GST_H264_NAL_PPS:
-    case GST_H264_NAL_SEI:
-    case GST_H264_NAL_PREFIX_UNIT:
-    case GST_H264_NAL_SUBSET_SPS:
-    case GST_H264_NAL_DEPTH_SPS:
-    case GST_H264_NAL_RSV_1:
-    case GST_H264_NAL_RSV_2:
-      ret = TRUE;
-      break;
-    default:
-      break;
-  }
-  return ret;
-}
-
-static GstH264ParseBacklogStatus
-gst_h264_parse_update_backlog (GstH264Parse * h264parse, GstH264NalUnit * nalu)
-{
-  gboolean is_first_vcl_nal = FALSE;
-  GstH264ParserResult pres;
-  GstH264SliceHdr slice_hdr;
-  gboolean nvcl_before_cau_vcl = FALSE;
-
-  g_array_append_val (h264parse->nal_backlog, *nalu);
-
-#define LAST_IDX  (h264parse->nal_backlog->len -1)
-
-  /* Update nal_backlog_potential_au_first_idx following
-   * ref. ITU-T H.264 7.4.1.2.3 */
-  switch (nalu->type) {
-    case GST_H264_NAL_SLICE:
-    case GST_H264_NAL_SLICE_DPA:
-    case GST_H264_NAL_SLICE_DPB:
-    case GST_H264_NAL_SLICE_DPC:
-    case GST_H264_NAL_SLICE_IDR:
-    case GST_H264_NAL_SLICE_EXT:
-      GST_DEBUG_OBJECT (h264parse, "vcl nal (%u) added to backlog", nalu->type);
-      pres = gst_h264_parser_parse_slice_hdr (h264parse->nalparser, nalu,
-          &slice_hdr, FALSE, FALSE);
-
-      if (pres == GST_H264_PARSER_OK) {
-        gst_h264_parse_update_vcl_nal_history (h264parse, nalu, &slice_hdr);
-        is_first_vcl_nal = gst_h264_parse_received_first_vcl_nal (h264parse);
-      } else {
-        /* Reset vcl nal history */
-        h264parse->history_slice[HIST_IDX_PREV].valid = FALSE;
-
-        /* Reset backlog */
-        h264parse->bl_curr_au_last_vcl = -1;
-        h264parse->bl_next_au_first_vcl = 1;
-        h264parse->bl_next_au_first_nal = 1;
-        h264parse->bl_next_nal = 0;
-        g_array_set_size (h264parse->nal_backlog, 0);
-
-        GST_DEBUG_OBJECT (h264parse, "Failed to parse slice header");
-        return GST_H264_PARSE_BACKLOG_STATUS_UPD_FAILED;
-      }
-
-      if (h264parse->bl_curr_au_last_vcl == -1) {
-        /* initialization, first vcl nal reception */
-        h264parse->bl_curr_au_last_vcl = LAST_IDX;
-
-        /* set index above backlog, meaning not received */
-        h264parse->bl_next_au_first_vcl = h264parse->nal_backlog->len;
-        h264parse->bl_next_au_first_nal = h264parse->bl_next_au_first_vcl;
-      } else {
-
-        if (is_first_vcl_nal) {
-          h264parse->bl_next_au_first_vcl = LAST_IDX;
-
-          /* First AUD, SPS, PPS, SEI, PREFIX_UNIT, SUBSET_SPS, DEPTH_SPS,
-           * RSV1, RSV2 between last vcl nal of current AU and first vcl nal
-           * of next AU define the first nal of the next AU, otherwise
-           * first vcl nal of next AU is the first nal on next AU.*/
-          if (h264parse->bl_next_au_first_nal <= h264parse->bl_curr_au_last_vcl)
-            h264parse->bl_next_au_first_nal = h264parse->bl_next_au_first_vcl;
-          else
-            g_assert (h264parse->bl_next_au_first_nal <=
-                h264parse->bl_next_au_first_vcl);
-
-        } else {
-          h264parse->bl_next_au_first_vcl = h264parse->nal_backlog->len;
-
-          /*if previous vcl nal was not the last, non vcl nal can't be last,
-           * therefore we move index of last nal to the last received vcl
-           * nal.*/
-          h264parse->bl_next_au_first_nal = h264parse->bl_next_au_first_vcl;
-        }
-      }
-
-      break;
-    default:
-      if (h264parse->bl_curr_au_last_vcl == -1) {
-        /* if we didn't receive any vcl, any nal from next au hasn't been
-         * received yet. In this state all nal from backlog belong to
-         * current AU. */
-        h264parse->bl_next_au_first_nal = h264parse->nal_backlog->len;
-        h264parse->bl_next_au_first_vcl = h264parse->nal_backlog->len;
-      }
-
-      nvcl_before_cau_vcl =
-          h264parse->bl_next_au_first_nal <= h264parse->bl_curr_au_last_vcl;
-
-      if (is_potential_nonvcl_au_limit (nalu)) {
-        /* these nal define the the first nal of a new AU if they are between
-         * the last vcl nal (of current AU) and first vcl (of next AU).*/
-        if (nvcl_before_cau_vcl)
-          h264parse->bl_next_au_first_nal = LAST_IDX;
-
-        /* Not the most efficient way has this will done again in _process_nal
-         * but sps and pps must be parsed before parsing s slice hdr. */
-        if (nalu->type == GST_H264_NAL_SPS) {
-          GstH264SPS sps;
-          gst_h264_parser_parse_sps (h264parse->nalparser, nalu, &sps);
-
-          g_return_val_if_fail (sps.profile_idc !=
-              GST_H264_PROFILE_SCALABLE_BASELINE
-              && sps.profile_idc != GST_H264_PROFILE_SCALABLE_HIGH,
-              GST_H264_PARSE_BACKLOG_STATUS_NOT_SUPPORTED);
-        } else if (nalu->type == GST_H264_NAL_PPS) {
-          GstH264PPS pps;
-          gst_h264_parser_parse_pps (h264parse->nalparser, nalu, &pps);
-        } else if (nalu->type == GST_H264_NAL_SUBSET_SPS) {
-          GstH264SPS sps;
-          gst_h264_parser_parse_subset_sps (h264parse->nalparser, nalu, &sps);
-          g_return_val_if_fail (sps.profile_idc !=
-              GST_H264_PROFILE_SCALABLE_BASELINE
-              && sps.profile_idc != GST_H264_PROFILE_SCALABLE_HIGH,
-              GST_H264_PARSE_BACKLOG_STATUS_NOT_SUPPORTED);
-        }
-      }
-      GST_DEBUG_OBJECT (h264parse, "Non-vcl nal (%u) added to backlog",
-          nalu->type);
-      break;
-  }
-
-  return is_first_vcl_nal ? GST_H264_PARSE_BACKLOG_STATUS_AU_COMPLETE :
-      GST_H264_PARSE_BACKLOG_STATUS_AU_INCOMPLETE;
-}
-
-static void
-gst_h264_parse_trim_backlog (GstH264Parse * h264parse)
-{
-  g_array_remove_range (h264parse->nal_backlog, 0,
-      h264parse->bl_next_au_first_nal);
-  h264parse->bl_next_nal = 0;
-  h264parse->bl_curr_au_last_vcl =
-      h264parse->bl_next_au_first_vcl - h264parse->bl_next_au_first_nal;
-  h264parse->bl_next_au_first_nal = h264parse->bl_curr_au_last_vcl + 1;
-  h264parse->bl_next_au_first_vcl = h264parse->bl_next_au_first_nal;
-}
-
-static void
-gst_h264_parse_clear_backlog (GstH264Parse * h264parse)
-{
-  h264parse->bl_next_nal = 0;
-  g_array_remove_range (h264parse->nal_backlog, 0, h264parse->nal_backlog->len);
-  h264parse->bl_curr_au_last_vcl = -1;
-  h264parse->bl_next_au_first_nal = 1;
-  h264parse->bl_next_au_first_vcl = 1;
-}
-
-static gboolean
-gst_h264_parse_process_backlog_loop (GstH264Parse * h264parse,
-    gint curr_next_thresh, gboolean * aud_insert, guint8 * data,
-    gint * framesize)
-{
-  GstH264NalUnit *bnalu;
-  gint i, size = 0;
-
-  for (i = h264parse->bl_next_nal; i < h264parse->nal_backlog->len; i++) {
-    bnalu = &g_array_index (h264parse->nal_backlog, GstH264NalUnit, i);
-    if (i < curr_next_thresh) {
-      if (aud_insert != NULL && i == 0 &&
-          bnalu->type != GST_H264_NAL_AU_DELIMITER)
-        *aud_insert = TRUE;
-
-      bnalu->data = (guint8 *) data;
-      if (gst_h264_parse_process_nal (h264parse, bnalu) == FALSE)
-        return FALSE;
-
-      size = bnalu->offset + bnalu->size;
-      h264parse->bl_next_nal = i + 1;
-    } else {
-      /* section of backlog that belong to next AU */
-      bnalu->offset -= size;
-      bnalu->sc_offset -= size;
-    }
-  }
-
-  *framesize += size;
-  return TRUE;
-}
-
-static gboolean
-gst_h264_parse_process_backlog_nal (GstH264Parse * h264parse, gint * proc_size,
-    gboolean * aud_insert, guint8 * data, gboolean clear_bl,
-    gboolean au_completed)
-{
-  GstH264NalUnit *bnalu;
-  gint framesize = 0;
-
-  g_assert (h264parse->nal_backlog != NULL);
-  g_assert (h264parse->nal_backlog->len > 0);
-
-  bnalu = &g_array_index (h264parse->nal_backlog, GstH264NalUnit,
-      h264parse->nal_backlog->len - 1);
-  h264parse->current_off = bnalu->offset + bnalu->size;
-
-  /* If the index of the first NAL from next AU is after the current AU vcl
-   * and the AU is not completed, we can't send the this nal downstream since
-   * we might need to insert a AUD before and we will only know this when we've
-   * received a new vcl nal. In this scenario even if we are in NAL alignment
-   * mode we have to keep non vcl NAL, that can start a AU, and only send them
-   * down stream when we know if the belong to current AU, in which case we
-   * just send them or belong if it belong to next AU where we might need to
-   * insert a AUD. If the first nal from next AU is a AUD we don't need to wait
-   * the completion the first vcl from next AU, AUD is the start of next AU.
-   */
-  if (gst_h264_parse_process_backlog_loop (h264parse,
-          h264parse->bl_next_au_first_nal, aud_insert, data,
-          &framesize) == FALSE)
-    goto fail;
-
-  /* We've processed a complete AU */
-  if (au_completed) {
-    gst_h264_parse_trim_backlog (h264parse);
-  }
-
-  /* Process all backlog. Used when draining or output in NAL mode. */
-  if (gst_h264_parse_process_backlog_loop (h264parse,
-          h264parse->nal_backlog->len, aud_insert, data, &framesize) == FALSE)
-    goto fail;
-
-  if (clear_bl) {
-    gst_h264_parse_clear_backlog (h264parse);
-  }
-
-  /* Backlog content doesn't need to parsed again, adjust offset accordingly. */
-  h264parse->current_off -= framesize;
-
-  if (proc_size)
-    *proc_size = framesize;
-
-  return TRUE;
-
-fail:
-  gst_h264_parse_clear_backlog (h264parse);
-  return FALSE;
-}
-
-static gboolean
-gst_h264_parse_process_backlog (GstH264Parse * h264parse, gint * proc_size,
-    gboolean * aud_insert, guint8 * data, gboolean proc_nau, gboolean clear_bl)
-{
-  GstH264NalUnit *bnalu;
-  gint framesize = 0;
-
-  g_assert (h264parse->nal_backlog != NULL);
-  g_assert (h264parse->nal_backlog->len > 0);
-
-  bnalu = &g_array_index (h264parse->nal_backlog, GstH264NalUnit,
-      h264parse->nal_backlog->len - 1);
-  h264parse->current_off = bnalu->offset + bnalu->size;
-
-  if (gst_h264_parse_process_backlog_loop (h264parse,
-          h264parse->bl_next_au_first_nal, aud_insert, data,
-          &framesize) == FALSE)
-    goto fail;
-
-  /* We've processed a complete AU */
-  if (h264parse->bl_next_au_first_nal < h264parse->nal_backlog->len) {
-    gst_h264_parse_trim_backlog (h264parse);
-  }
-
-  /* Process all backlog. Used when draining or output in NAL mode. */
-  if (proc_nau) {
-    if (gst_h264_parse_process_backlog_loop (h264parse,
-            h264parse->nal_backlog->len, aud_insert, data, &framesize) == FALSE)
-      goto fail;
-  }
-
-  if (clear_bl) {
-    gst_h264_parse_clear_backlog (h264parse);
-  }
-
-  /* What is in the backlog doesn't need to parsed again, adjust offset
-   * accordingly.*/
-  h264parse->current_off -= framesize;
-
-  if (proc_size)
-    *proc_size = framesize;
-
-  return TRUE;
-
-fail:
-  gst_h264_parse_clear_backlog (h264parse);
-
-  return FALSE;
-}
-
 static GstFlowReturn
 gst_h264_parse_handle_frame (GstBaseParse * parse,
     GstBaseParseFrame * frame, gint * skipsize)
@@ -1812,12 +1348,9 @@ gst_h264_parse_handle_frame (GstBaseParse * parse,
   GstH264NalUnit nalu;
   GstH264ParserResult pres;
   gint framesize;
-  GstH264ParseBacklogStatus blstatus = FALSE;
 
   if (G_UNLIKELY (GST_BUFFER_FLAG_IS_SET (frame->buffer,
               GST_BUFFER_FLAG_DISCONT))) {
-    // If any input buffer is marked discont we propagate discont
-    // to parsed output buffer.
     h264parse->discont = TRUE;
   }
 
@@ -1861,28 +1394,14 @@ gst_h264_parse_handle_frame (GstBaseParse * parse,
 
   /* The parser is being drain, but no new data was added, just prentend this
    * AU is complete */
-  if (current_off == size) {
-    if (drain) {
-      GST_DEBUG_OBJECT (h264parse, "draining with no new data");
-      framesize = current_off;
-      if (!gst_h264_parse_process_backlog (h264parse, &framesize,
-              &h264parse->aud_insert, data, TRUE, FALSE)) {
-        *skipsize = current_off;
-        goto skip;
-      }
-
-      goto end;
-    } else {
-      /* All data already parsed, we need more data. */
-      goto more;
-    }
+  if (drain && current_off == size) {
+    GST_DEBUG_OBJECT (h264parse, "draining with no new data");
+    nalu.size = 0;
+    nalu.offset = current_off;
+    goto end;
   }
 
-  /* In some case the base class can reduce the amount of data it gave us on
-   * previous call. When this happen we just ask for more data. */
-  if (current_off > size) {
-    goto more;
-  }
+  g_assert (current_off < size);
   GST_DEBUG_OBJECT (h264parse, "last parse position %d", current_off);
 
   /* check for initial skip */
@@ -1922,9 +1441,6 @@ gst_h264_parse_handle_frame (GstBaseParse * parse,
       case GST_H264_PARSER_OK:
         GST_DEBUG_OBJECT (h264parse, "complete nal (offset, size): (%u, %u) ",
             nalu.offset, nalu.size);
-
-        if ((nalu.offset + nalu.size) == size)
-          nonext = TRUE;
         break;
       case GST_H264_PARSER_NO_NAL:
         /* In NAL alignment, assume the NAL is broken */
@@ -1978,16 +1494,11 @@ gst_h264_parse_handle_frame (GstBaseParse * parse,
         if (current_off == 0) {
           GST_DEBUG_OBJECT (h264parse, "skipping broken nal");
           *skipsize = nalu.offset;
-          h264parse->current_off = -1;
           goto skip;
         } else {
           GST_DEBUG_OBJECT (h264parse, "terminating au");
-          framesize = nalu.sc_offset;
-          if (!gst_h264_parse_process_backlog (h264parse, &framesize,
-                  &h264parse->aud_insert, data, FALSE, TRUE)) {
-            *skipsize = current_off;
-            goto skip;
-          }
+          nalu.size = 0;
+          nalu.offset = nalu.sc_offset;
           goto end;
         }
         break;
@@ -1996,73 +1507,79 @@ gst_h264_parse_handle_frame (GstBaseParse * parse,
         break;
     }
 
-    blstatus = gst_h264_parse_update_backlog (h264parse, &nalu);
-    if (blstatus == GST_H264_PARSE_BACKLOG_STATUS_UPD_FAILED) {
-      *skipsize = current_off;
-      GST_ERROR_OBJECT (h264parse, "Failed to update backlog");
+    GST_DEBUG_OBJECT (h264parse, "%p complete nal found. Off: %u, Size: %u",
+        data, nalu.offset, nalu.size);
+
+    if (gst_h264_parse_collect_nal (h264parse, &nalu)) {
+      h264parse->aud_needed = TRUE;
+      /* complete current frame, if it exist */
+      if (current_off > 0) {
+        nalu.size = 0;
+        nalu.offset = nalu.sc_offset;
+        h264parse->marker = TRUE;
+        break;
+      }
+    }
+
+    if (!gst_h264_parse_process_nal (h264parse, &nalu)) {
+      GST_WARNING_OBJECT (h264parse,
+          "broken/invalid nal Type: %d %s, Size: %u will be dropped",
+          nalu.type, _nal_name (nalu.type), nalu.size);
+      *skipsize = nalu.size;
       goto skip;
-    } else if (blstatus == GST_H264_PARSE_BACKLOG_STATUS_NOT_SUPPORTED) {
-      /* SVC is not supported */
-      GST_ELEMENT_ERROR (h264parse, STREAM, FORMAT,
-          ("Error parsing H.264 stream"), ("Not supported H.264 stream"));
-      goto invalid_stream;
     }
 
-    if (h264parse->align == GST_H264_PARSE_ALIGN_NAL) {
-      if (!gst_h264_parse_process_backlog_nal (h264parse, &framesize,
-              &h264parse->aud_insert, data, FALSE,
-              blstatus == GST_H264_PARSE_BACKLOG_STATUS_AU_COMPLETE)) {
-        *skipsize = current_off;
-      }
-
-      if (framesize > 0)
-        goto end;
-
-    } else if (h264parse->align == GST_H264_PARSE_ALIGN_AU) {
-      if (h264parse->in_align != GST_H264_PARSE_ALIGN_AU) {
-        if (blstatus == GST_H264_PARSE_BACKLOG_STATUS_AU_COMPLETE) {
-          if (!gst_h264_parse_process_backlog (h264parse, &framesize,
-                  &h264parse->aud_insert, data, FALSE, FALSE)) {
-            *skipsize = current_off;
-            goto skip;
-          }
-
-          if (framesize > 0)
-            goto end;
-
-        } else if (drain && nonext) {
-          if (!gst_h264_parse_process_backlog (h264parse, &framesize,
-                  &h264parse->aud_insert, data, TRUE, FALSE)) {
-            *skipsize = current_off;
-            goto skip;
-          }
-          goto end;
-        }
-      } else {
-
-        /* Accumulate all NALs from current AU in backlog */
-        if (nonext) {
-          /* input and output alignment are AU, there's nothing to do more than
-           * inserting a AUD if it's missing. */
-          if (!gst_h264_parse_process_backlog (h264parse, &framesize,
-                  &h264parse->aud_insert, data, TRUE, TRUE)) {
-            *skipsize = current_off;
-            goto skip;
-          }
-          goto end;
-        }
-      }
+    /* Make sure the next buffer will contain an AUD */
+    if (h264parse->aud_needed) {
+      h264parse->aud_insert = TRUE;
+      h264parse->aud_needed = FALSE;
     }
 
+    /* Do not push immediately if we don't have all headers. This ensure that
+     * our caps are complete, avoiding a renegotiation */
+    if (h264parse->align == GST_H264_PARSE_ALIGN_NAL &&
+        !GST_H264_PARSE_STATE_VALID (h264parse,
+            GST_H264_PARSE_STATE_VALID_PICTURE_HEADERS))
+      frame->flags |= GST_BASE_PARSE_FRAME_FLAG_QUEUE;
+
+    /* if no next nal, we reached the end of this buffer */
     if (nonext) {
+      /* If there is a marker flag, or input is AU, we know this is complete */
+      if (GST_BUFFER_FLAG_IS_SET (frame->buffer, GST_BUFFER_FLAG_MARKER) ||
+          h264parse->in_align == GST_H264_PARSE_ALIGN_AU) {
+        h264parse->marker = TRUE;
+        break;
+      }
+
+      /* or if we are draining */
+      if (drain || h264parse->align == GST_H264_PARSE_ALIGN_NAL)
+        break;
+
       current_off = nalu.offset + nalu.size;
       goto more;
     }
 
+    /* If the output is NAL, we are done */
+    if (h264parse->align == GST_H264_PARSE_ALIGN_NAL)
+      break;
+
+    GST_DEBUG_OBJECT (h264parse, "Looking for more");
     current_off = nalu.offset + nalu.size;
-  }                             /* while end */
+
+    /* expect at least 3 bytes start_code, and 1 bytes NALU header.
+     * the length of the NALU payload can be zero.
+     * (e.g. EOS/EOB placed at the end of an AU.) */
+    if (size - current_off < 4) {
+      /* Finish the frame if there is no more data in the stream */
+      if (drain)
+        break;
+
+      goto more;
+    }
+  }
 
 end:
+  framesize = nalu.offset + nalu.size;
 
   gst_buffer_unmap (buffer, &map);
 

--- a/subprojects/gst-plugins-bad/gst/videoparsers/gsth264parse.c
+++ b/subprojects/gst-plugins-bad/gst/videoparsers/gsth264parse.c
@@ -1483,6 +1483,8 @@ gst_h264_parse_received_first_vcl_nal (GstH264Parse * h264parse)
       default:
         return FALSE;
     }
+    return gst_h264_parse_received_first_vcl_nal_base (h264parse,
+        slice_hdr_prev);
   }
   return FALSE;
 }

--- a/subprojects/gst-plugins-bad/gst/videoparsers/gsth264parse.c
+++ b/subprojects/gst-plugins-bad/gst/videoparsers/gsth264parse.c
@@ -224,7 +224,6 @@ gst_h264_parse_init (GstH264Parse * h264parse)
   h264parse->bl_next_au_first_vcl = 1;
   h264parse->bl_next_au_first_nal = 1;
   h264parse->bl_next_nal = 0;
-  h264parse->bl_last_aud_nal = -1;
 
   h264parse->history_slice[HIST_IDX_CURR].valid = FALSE;
   h264parse->history_slice[HIST_IDX_PREV].valid = FALSE;
@@ -1547,7 +1546,6 @@ gst_h264_parse_update_backlog (GstH264Parse * h264parse, GstH264NalUnit * nalu)
         h264parse->bl_next_au_first_vcl = 1;
         h264parse->bl_next_au_first_nal = 1;
         h264parse->bl_next_nal = 0;
-        h264parse->bl_last_aud_nal = -1;
         g_array_set_size (h264parse->nal_backlog, 0);
 
         GST_DEBUG_OBJECT (h264parse, "Failed to parse slice header");
@@ -1563,12 +1561,6 @@ gst_h264_parse_update_backlog (GstH264Parse * h264parse, GstH264NalUnit * nalu)
         h264parse->bl_next_au_first_nal = h264parse->bl_next_au_first_vcl;
       } else {
 
-        if (!is_first_vcl_nal) {
-          is_first_vcl_nal =
-              h264parse->bl_last_aud_nal > h264parse->bl_curr_au_last_vcl;
-        }
-
-        h264parse->bl_last_aud_nal = -1;
         if (is_first_vcl_nal) {
           h264parse->bl_next_au_first_vcl = LAST_IDX;
 
@@ -1593,8 +1585,6 @@ gst_h264_parse_update_backlog (GstH264Parse * h264parse, GstH264NalUnit * nalu)
       }
 
       break;
-    case GST_H264_NAL_AU_DELIMITER:
-      h264parse->bl_last_aud_nal = LAST_IDX;
     default:
       if (h264parse->bl_curr_au_last_vcl == -1) {
         /* if we didn't receive any vcl, any nal from next au hasn't been
@@ -1652,7 +1642,6 @@ gst_h264_parse_trim_backlog (GstH264Parse * h264parse)
   h264parse->bl_next_nal = 0;
   h264parse->bl_curr_au_last_vcl =
       h264parse->bl_next_au_first_vcl - h264parse->bl_next_au_first_nal;
-  h264parse->bl_last_aud_nal -= h264parse->bl_curr_au_last_vcl;
   h264parse->bl_next_au_first_nal = h264parse->bl_curr_au_last_vcl + 1;
   h264parse->bl_next_au_first_vcl = h264parse->bl_next_au_first_nal;
 }
@@ -1665,8 +1654,6 @@ gst_h264_parse_clear_backlog (GstH264Parse * h264parse)
   h264parse->bl_curr_au_last_vcl = -1;
   h264parse->bl_next_au_first_nal = 1;
   h264parse->bl_next_au_first_vcl = 1;
-  h264parse->bl_last_aud_nal = -1;
-
 }
 
 static gboolean
@@ -2009,8 +1996,8 @@ gst_h264_parse_handle_frame (GstBaseParse * parse,
 
     blstatus = gst_h264_parse_update_backlog (h264parse, &nalu);
     if (blstatus == GST_H264_PARSE_BACKLOG_STATUS_UPD_FAILED) {
-      *skipsize = nalu.size + nalu.offset;
-      GST_WARNING_OBJECT (h264parse, "Failed to update backlog");
+      *skipsize = current_off;
+      GST_ERROR_OBJECT (h264parse, "Failed to update backlog");
       goto skip;
     } else if (blstatus == GST_H264_PARSE_BACKLOG_STATUS_NOT_SUPPORTED) {
       /* SVC is not supported */
@@ -2100,10 +2087,8 @@ skip:
    * slice NAL was received. This means that broken pictures are discarded */
   if (h264parse->align != GST_H264_PARSE_ALIGN_AU ||
       !(h264parse->state & GST_H264_PARSE_STATE_VALID_PICTURE_HEADERS) ||
-      (h264parse->state & GST_H264_PARSE_STATE_GOT_SLICE)) {
+      (h264parse->state & GST_H264_PARSE_STATE_GOT_SLICE))
     gst_h264_parse_reset_frame (h264parse);
-    h264parse->current_off = -1;
-  }
   goto out;
 
 invalid_stream:

--- a/subprojects/gst-plugins-bad/gst/videoparsers/gsth264parse.h
+++ b/subprojects/gst-plugins-bad/gst/videoparsers/gsth264parse.h
@@ -48,40 +48,6 @@ typedef struct _H264Params H264Params;
 
 GType gst_h264_parse_get_type (void);
 
-typedef struct
-{
-  gboolean valid;
-  guint16 frame_num;
-  guint8 field_pic_flag;
-  guint8 bottom_field_flag;
-  guint16 idr_pic_id;
-  gint32 delta_pic_order_cnt[2];
-  guint16 pic_order_cnt_lsb;
-  guint32 delta_pic_order_cnt_bottom;
-  guint32 first_mb_in_slice;
-} GstH264ParseHistorySlice;
-
-typedef struct
-{
-  guint16 ref_idc;
-  guint8 idr_pic_flag;
-
-  /* For MVC Extension */
-  guint16 view_id;
-} GstH264ParseHistoryNalUnit;
-
-typedef struct
-{
-  guint8 pic_order_cnt_type;
-  guint8 profile_idc;
-} GstH264ParseHistorySPS;
-
-typedef struct
-{
-  gint id;
-} GstH264ParseHistoryPPS;
-
-
 typedef struct _GstH264Parse GstH264Parse;
 typedef struct _GstH264ParseClass GstH264ParseClass;
 
@@ -191,21 +157,6 @@ struct _GstH264Parse
   GstVideoMultiviewFlags multiview_flags;
   gboolean first_in_bundle;
 
-  /* For insertion of AU Delimiter */
-  GArray *nal_backlog;
-
-  /* Index of last vcl nal of current AU in backlog */
-  gint bl_curr_au_last_vcl;
-
-  /* Index of first vcl nal of next AU in backlog */
-  gint bl_next_au_first_vcl;
-
-  /* Index of first nal of next AU in backlog */
-  gint bl_next_au_first_nal;
-
-  /* Index of next nal to be processed in backlog */
-  gint bl_next_nal;
-
   GstVideoParseUserData user_data;
   GstVideoParseUserDataUnregistered user_data_unregistered;
 
@@ -217,12 +168,6 @@ struct _GstH264Parse
 
   /* For forward predicted trickmode */
   gboolean discard_bidirectional;
-
-  /* First VCL NAL unit of primary code picuture detection context */
-  GstH264ParseHistorySlice history_slice[2];
-  GstH264ParseHistoryNalUnit history_nalu[2];
-  GstH264ParseHistorySPS history_sps[2];
-  GstH264ParseHistoryPPS history_pps[2];
 };
 
 struct _GstH264ParseClass

--- a/subprojects/gst-plugins-bad/gst/videoparsers/gsth264parse.h
+++ b/subprojects/gst-plugins-bad/gst/videoparsers/gsth264parse.h
@@ -206,9 +206,6 @@ struct _GstH264Parse
   /* Index of next nal to be processed in backlog */
   gint bl_next_nal;
 
-  /* Index of last AUD */
-  gint bl_last_aud_nal;
-
   GstVideoParseUserData user_data;
   GstVideoParseUserDataUnregistered user_data_unregistered;
 

--- a/subprojects/gst-plugins-bad/tests/check/elements/h264parse.c
+++ b/subprojects/gst-plugins-bad/tests/check/elements/h264parse.c
@@ -1106,58 +1106,6 @@ GST_START_TEST (test_parse_sliced_nal_au)
 }
 
 GST_END_TEST;
-/* These were generated using this pipeline, on a zynqultrascaleplus:
- *
- * gst-launch-1.0 videotestsrc num-buffers=1 pattern=green \
- *     ! video/x-raw,width=128,height=128 \
- *     ! omxh264enc num-slices=2 gop-mode=pyramidal gop-length=60 b-frames=3 \
- *     ! video/x-h264, profile=high-4:2:2 \
- *     ! fakesink dump=1
- *
- * This uses a special feature of the encoder ("temporal encoding")
- * that causes it to output PREFIX NALs before each slice.
- */
-
-/* SPS */
-static guint8 h264_prefixed_sps[] = {
-  0x00, 0x00, 0x00, 0x01, 0x27, 0x7a, 0x00, 0x0b,
-  0xad, 0x00, 0xce, 0x50, 0x81, 0x1a, 0x6a, 0x0c,
-  0x04, 0x05, 0xe0, 0x00, 0x00, 0x03, 0x00, 0x20,
-  0x00, 0x00, 0x07, 0x96, 0x6a, 0x07, 0xd0, 0x0b,
-  0xbf, 0xff, 0xf8, 0x14
-};
-
-/* PPS */
-static guint8 h264_prefixed_pps[] = {
-  0x00, 0x00, 0x00, 0x01, 0x28, 0xe9, 0x08, 0x3c,
-  0xb0
-};
-
-static guint8 h264_prefixed_idr_slice_1[] = {
-  /* prefix */
-  0x00, 0x00, 0x00, 0x01, 0x0e, 0xc0, 0x80, 0x07,
-  /* IDR Slice 1 */
-  0x00, 0x00, 0x00, 0x01, 0x25, 0xb8, 0x40, 0x00,
-  0x45, 0xbf, 0x53, 0x39, 0xfb, 0xf7, 0xff, 0x07,
-  0x23, 0x20, 0x25, 0xb3, 0xf6, 0x38, 0x79, 0x10,
-  0xed, 0x91, 0x7b, 0xbc, 0x60, 0x7c, 0x36, 0x2f,
-  0x8d, 0x9d, 0x5e, 0xcb, 0xed, 0x70, 0x6d, 0xba,
-  0x50, 0x9e, 0x5c, 0x76, 0x6a, 0xa6, 0xc9, 0xf8,
-  0x0f
-};
-
-static guint8 h264_prefixed_idr_slice_2[] = {
-  /* prefix */
-  0x00, 0x00, 0x00, 0x01, 0x0e, 0xc0, 0x80, 0x07,
-  /* IDR Slice 2 */
-  0x00, 0x00, 0x00, 0x01, 0x25, 0x04, 0x2e, 0x10,
-  0x00, 0x11, 0x6f, 0x53, 0x39, 0xfb, 0xf7, 0xff,
-  0x07, 0x23, 0x20, 0x25, 0xb3, 0xf6, 0x38, 0x79,
-  0x10, 0xed, 0x91, 0x7b, 0xbc, 0x60, 0x7c, 0x36,
-  0x2f, 0x8d, 0x9d, 0x5e, 0xcb, 0xed, 0x70, 0x6d,
-  0xba, 0x50, 0x9e, 0x5c, 0x76, 0x6a, 0xa6, 0xc9,
-  0xf8, 0x0f
-};
 
 GST_START_TEST (test_parse_sliced_sps_pps_sps)
 {
@@ -1228,68 +1176,6 @@ GST_START_TEST (test_parse_sliced_sps_pps_sps)
 
 GST_END_TEST;
 
-GST_START_TEST (test_parse_sliced_with_prefix_and_sei_nal_au)
-{
-  /* Insert an SEI between slices of first frame, checks that AUD gets
-   * inserted after SLICE2 and not before the SEI.
-   * <AUD> | SPS | PPS | PREFIX_UNIT | SLICE1 mb=0 | SEI | PREFIX_UNIT | SLICE2
-   * <AUD> | PREFIX_UNIT | SLICE1
-   */
-  GstHarness *h = gst_harness_new ("h264parse");
-  GstBuffer *buf;
-  GstMapInfo info;
-
-  gst_harness_set_caps_str (h,
-      "video/x-h264,stream-format=byte-stream,alignment=nal,parsed=false,framerate=30/1",
-      "video/x-h264,stream-format=byte-stream,alignment=au,parsed=true");
-
-  /* Frame 1 */
-  buf = wrap_buffer (h264_prefixed_sps, sizeof (h264_prefixed_sps), 10, 0);
-  fail_unless_equals_int (gst_harness_push (h, buf), GST_FLOW_OK);
-
-  buf = wrap_buffer (h264_prefixed_pps, sizeof (h264_prefixed_pps), 10, 0);
-  fail_unless_equals_int (gst_harness_push (h, buf), GST_FLOW_OK);
-
-  /* 1st slice of first frame */
-  buf =
-      wrap_buffer (h264_prefixed_idr_slice_1,
-      sizeof (h264_prefixed_idr_slice_1), 10, 0);
-  fail_unless_equals_int (gst_harness_push (h, buf), GST_FLOW_OK);
-
-  /* SEI */
-  buf =
-      wrap_buffer (h264_sei_buffering_period,
-      sizeof (h264_sei_buffering_period), 10, 0);
-  fail_unless_equals_int (gst_harness_push (h, buf), GST_FLOW_OK);
-
-  /* 2nd slice of first frame */
-  buf =
-      wrap_buffer (h264_prefixed_idr_slice_2,
-      sizeof (h264_prefixed_idr_slice_2), 10, 0);
-  fail_unless_equals_int (gst_harness_push (h, buf), GST_FLOW_OK);
-
-  /* Push first slice of 2nd frame, that should produce the 1st frame */
-  buf =
-      wrap_buffer (h264_prefixed_idr_slice_1,
-      sizeof (h264_prefixed_idr_slice_1), 100, 0);
-  fail_unless_equals_int (gst_harness_push (h, buf), GST_FLOW_OK);
-
-  /* Parser produces frame 1 */
-  buf = composite_buffer (10, 0, 6,
-      h264_aud, sizeof (h264_aud),
-      h264_prefixed_sps, sizeof (h264_prefixed_sps),
-      h264_prefixed_pps, sizeof (h264_prefixed_pps),
-      h264_prefixed_idr_slice_1, sizeof (h264_prefixed_idr_slice_1),
-      h264_sei_buffering_period, sizeof (h264_sei_buffering_period),
-      h264_prefixed_idr_slice_2, sizeof (h264_prefixed_idr_slice_2));
-  gst_buffer_map (buf, &info, GST_MAP_READ);
-  pull_and_check_full (h, info.data, info.size, 10, 0);
-  gst_buffer_unmap (buf, &info);
-  gst_buffer_unref (buf);
-  gst_harness_teardown (h);
-}
-
-GST_END_TEST;
 
 static Suite *
 h264parse_sliced_suite (void)
@@ -1302,7 +1188,6 @@ h264parse_sliced_suite (void)
   tcase_add_test (tc_chain, test_parse_sliced_au_nal);
   tcase_add_test (tc_chain, test_parse_sliced_nal_au);
   tcase_add_test (tc_chain, test_parse_sliced_sps_pps_sps);
-  tcase_add_test (tc_chain, test_parse_sliced_with_prefix_and_sei_nal_au);
 
   return s;
 }


### PR DESCRIPTION
This reverts PRs that caused the regression with h264parse which causes crashes on some NVRs. See: [slack](https://coramai.slack.com/archives/C03BS2W7GQN/p1712612390383719)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/orcamobility/gstreamer/17)
<!-- Reviewable:end -->
