### PR TITLE
nvh264dec, nvh265dec: Fix deadlock on corrupt SPS by returning GST_FLOW_ERROR

### DIFF
--- a/subprojects/gst-plugins-bad/sys/nvcodec/gstnvh264dec.cpp
+++ b/subprojects/gst-plugins-bad/sys/nvcodec/gstnvh264dec.cpp
@@ -636,10 +636,9 @@ gst_nv_h264_dec_new_sequence (GstH264Decoder * decoder, const GstH264SPS * sps,
     if (!gst_video_info_set_format (&info, out_format, self->width,
             self->height)) {
       GST_WARNING_OBJECT (self,
-          "Failed to set video info, format %s, width %u, height %u, "
-          "skipping reconfiguration and waiting for valid SPS",
+          "Failed to set video info, format %s, width %u, height %u",
           gst_video_format_to_string (out_format), self->width, self->height);
-      return GST_FLOW_OK;
+      return GST_FLOW_ERROR;
     }
 
     if (self->interlaced)

--- a/subprojects/gst-plugins-bad/sys/nvcodec/gstnvh265dec.cpp
+++ b/subprojects/gst-plugins-bad/sys/nvcodec/gstnvh265dec.cpp
@@ -648,11 +648,10 @@ gst_nv_h265_dec_new_sequence (GstH265Decoder * decoder, const GstH265SPS * sps,
     if (!gst_video_info_set_format (&info,
             self->out_format, self->width, self->height)) {
       GST_WARNING_OBJECT (self,
-          "Failed to set video info, format %s, width %u, height %u, "
-          "skipping reconfiguration and waiting for valid SPS",
+          "Failed to set video info, format %s, width %u, height %u",
           gst_video_format_to_string (self->out_format), self->width,
           self->height);
-      return GST_FLOW_OK;
+      return GST_FLOW_ERROR;
     }
 
     self->max_dpb_size = max_dpb_size;


### PR DESCRIPTION
## Summary

- Fix deadlock caused by returning `GST_FLOW_OK` from `new_sequence` when `gst_video_info_set_format` fails due to corrupt SPS crop offsets
- Return `GST_FLOW_ERROR` instead, which the base class catches via `GST_VIDEO_DECODER_ERROR` (with default `max_errors=-1`) and converts to `GST_FLOW_OK` — dropping the corrupt frame while keeping the pipeline alive
- Applies to both nvh264dec and nvh265dec

## Root Cause

When a corrupt H264/H265 SPS has invalid crop offsets, the crop rectangle calculation underflows producing huge dimensions (e.g. `width=4294966262`). `gst_video_info_set_format` fails, and the previous fix returned `GST_FLOW_OK` to keep the pipeline alive. However, this skipped `gst_nv_decoder_configure`, leaving the decoder without a surface pool. The base class then proceeded to decode slices, calling `gst_nv_dec_object_acquire_surface` which blocked forever waiting for surfaces that don't exist. This deadlocked the pipeline during shutdown when the state-change thread tried to acquire the streaming lock held by the blocked thread.

## Why GST_FLOW_ERROR works

- The base class `handle_frame` catches `GST_FLOW_ERROR` via `GST_VIDEO_DECODER_ERROR` macro, which with default `max_errors=-1` converts it to `GST_FLOW_OK` — frame is dropped, pipeline continues
- The corrupt SPS is not stored in the parser (`gst_h264_parser_update_sps` is skipped on error), so subsequent slices either fail safely at header parsing (PPS not found) or use a previously valid SPS
- Recovery is automatic when a valid SPS arrives

### Why not GST_FLOW_NOT_NEGOTIATED?

`handle_frame` (line 604) only catches `GST_FLOW_ERROR` via `GST_VIDEO_DECODER_ERROR`. `GST_FLOW_NOT_NEGOTIATED` would propagate directly to the pad and kill the pipeline.

## Edge Case Analysis

**Scenario 1: First SPS ever is corrupt, next frame has only slice NALs**
- `new_sequence` → `GST_FLOW_ERROR` → SPS not stored in parser (`gst_h264_parser_update_sps` skipped). PPS NAL in same AU also not processed (decode loop breaks on first error).
- Next slice: `gst_h264_parser_parse_slice_hdr` → PPS not found → `GST_H264_PARSER_BROKEN_LINK` → `GST_FLOW_ERROR` → frame dropped. **No deadlock.**

**Scenario 2: Same corrupt SPS arrives again**
- Base class `process_sps`: `priv->width` (not updated from last failure) != `sps->width` → change detected → `new_sequence` called again → `gst_video_info_set_format` fails again → `GST_FLOW_ERROR`. SPS still not stored.
- **No deadlock. Frame dropped.**

**Scenario 3: Valid SPS arrives after corrupt one**
- `process_sps` detects change → `new_sequence` called → `gst_video_info_set_format` succeeds → `gst_nv_decoder_configure` called → decoder configured → `GST_FLOW_OK` → SPS stored.
- **Recovery. Decoding resumes normally.**

**Scenario 4: Had previous valid sequence, corrupt SPS arrives, then slices without new SPS**
- `process_sps` detects change → drains DPB (pending pictures output) → `new_sequence` → `GST_FLOW_ERROR` → SPS NOT stored (old valid SPS remains in parser). `priv->width`/`priv->height` NOT updated.
- Next slice: `parse_slice_hdr` → finds old valid PPS/SPS → succeeds. Decoder still configured from old valid sequence → `acquire_surface` works.
- **No deadlock. Decoding continues with old config.**

**Scenario 5: Codec data path (AVC format) with corrupt SPS**
- `parse_codec_data` → `parse_sps` → `GST_FLOW_ERROR` → `parse_codec_data` returns error.
- Base class warns and continues: `"keep going without error. Probably inband SPS/PPS might be valid data"`.
- **No deadlock. Pipeline continues.**

**Scenario 6: Pipeline state change (NULL) while decoder is unconfigured**
- Streaming thread is not blocked on `acquire_surface` (frames are being dropped via `GST_FLOW_ERROR`).
- State change can deactivate pads and stop the streaming thread normally.
- **No deadlock. Clean shutdown.**

**Scenario 7: Stale `self->width`/`self->height` in nvh264dec/nvh265dec**
- These fields are only used inside `new_sequence` (for change detection and `gst_video_info_set_format`). Corrupt values persist but self-correct when a valid SPS arrives (`self->width (corrupt) != crop_width (valid)` → `modified = TRUE` → re-enters config block → properly configured).
- **Safe. Self-correcting.**

## Test plan

- [ ] Verify pipeline doesn't deadlock on corrupt SPS with invalid crop offsets
- [ ] Verify pipeline recovers when valid SPS arrives after corrupt one
- [ ] Verify clean shutdown works during corrupt SPS handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/orcamobility/gstreamer/25)
<!-- Reviewable:end -->
