### PR TITLE
feat(fmp4): update gst-plugins-rs to include header-update-mode=caps

### DIFF
--- a/subprojects/gst-plugins-rs.wrap
+++ b/subprojects/gst-plugins-rs.wrap
@@ -2,5 +2,5 @@
 directory=gst-plugins-rs
 url=https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git
 push-url=git@gitlab.freedesktop.org:gstreamer/gst-plugins-rs.git
-# 2025-04-14, main branch
-revision=800e4a579f25e9364161f81145ebde26a4405e5b
+# 2025-05-21, main branch
+revision=c3740cd6a9b24495ba128a4aabe82532cef3ff9e

--- a/subprojects/gst-plugins-rs.wrap
+++ b/subprojects/gst-plugins-rs.wrap
@@ -2,5 +2,5 @@
 directory=gst-plugins-rs
 url=https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git
 push-url=git@gitlab.freedesktop.org:gstreamer/gst-plugins-rs.git
-# 2025-01-15, main branch
-revision=8e62e54cc991919f26101bbf6e814e3d6858239c
+# 2025-04-14, main branch
+revision=800e4a579f25e9364161f81145ebde26a4405e5b


### PR DESCRIPTION
Bumps gst-plugins-rs from 8e62e54 (2025-01-15) to 800e4a57 (2025-04-14). This adds the HeaderUpdateMode::Caps variant to isofmp4mux, which automatically re-emits ftyp+moov headers when input caps change mid-stream (e.g. resolution changes during clip playback).