### PR TITLE
fix(fmp4): bump gst-plugins-rs to include late-GOP panic fix

### DIFF
--- a/subprojects/gst-plugins-rs.wrap
+++ b/subprojects/gst-plugins-rs.wrap
@@ -2,5 +2,5 @@
 directory=gst-plugins-rs
 url=https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git
 push-url=git@gitlab.freedesktop.org:gstreamer/gst-plugins-rs.git
-# 2025-04-14, main branch
-revision=800e4a579f25e9364161f81145ebde26a4405e5b
+# 2025-05-21, main branch
+revision=c3740cd6a9b24495ba128a4aabe82532cef3ff9e


### PR DESCRIPTION
## Summary

Stacks on #26 to bump the `gst-plugins-rs` pin from `800e4a57` (2025-04-14) to **`c3740cd6`** (2025-05-21), picking up upstream commit `fmp4mux: Fix handling of stream with late single GOP` ([MR !2236](https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/merge_requests/2236)).

## What's broken without this

`isofmp4mux` panics with:

```
thread '<unnamed>' panicked at mux/fmp4/src/fmp4mux/imp.rs:2705:
assertion failed: at_eos
```

triggered when:
- a stream's first GOP starts after the chunk/fragment end PTS (\"late GOP\"), or
- `drain_one_chunk` is re-entered after `state.need_new_header` is set (e.g. on a caps change during clip playback).

We hit this in production on the **HIGH (Original 3840x2160) → KinesisReady (1066x600) resolution switch** in the hybrid clip pipeline (logistics-core: `hybrid_clip_processor.cc:227`):

```
Resolution change detected, current clip log src is: KinesisReady,
current resolution is [1066, 600], last resolution is [3840,].

thread '<unnamed>' panicked at .../fmp4mux/imp.rs:2705:
assertion failed: at_eos

stack backtrace:
  17: gstfmp4::fmp4mux::imp::FMP4Mux::drain_one_chunk    imp.rs:2705
  18: gstfmp4::fmp4mux::imp::FMP4Mux::drain              imp.rs:2896
  19: ... AggregatorImpl::aggregate                      imp.rs:3912
```

The pipeline error surfaces as `Error received from element mux: Panicked: assertion failed: at_eos` + `Internal data stream error`, and the C++ watchdog tears the clip down via `hybrid_clip_processor.cc:340 (\"VideoSink pipeline ... became abnormal, stopping the clip playback early\")`.

## Upstream fix

[`c3740cd6` (Jochen Henneberg, Centricular)](https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/commit/c3740cd6a9b24495ba128a4aabe82532cef3ff9e) replaces the bad assertion:

```diff
 if interleaved_buffers.is_empty() {
-    assert!(at_eos);
+    // Either at EOS or only gap buffers drained.
     return Ok((caps, None));
 }
```

…and adds a `late_gop` retry path. Repro test [`cd45732f`](https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/commit/cd45732f7ca4486014591361cd7808db90dffdb5) (\"Added test to trigger panic on late GOP\", same author) reproduces this exact panic.

## Interaction with #26

#26 enables `header-update-mode=caps`, which is the right move — but it flips `state.need_new_header` more often, which makes the panic path in `drain_one_chunk` **more** reachable. Shipping #26 without this bump risks making crashes more frequent, not less. That's why this PR stacks on #26 rather than landing standalone.

## Range bumped

16 commits in `mux/fmp4/src/fmp4mux/imp.rs` between `800e4a57..c3740cd6`. Highlights (all fmp4mux-internal):

- `c3740cd6` fmp4mux: Fix handling of stream with late single GOP **← the actual fix**
- `144aeb61` fmp4mux: Fix handling of negative DTS in composition time offset
- `6df4adac` fmp4mux: Use earliest PTS for the base media decode time (tfdt)
- `86d2f2ce` fmp4mux: Write lmsg as compatible brand into last fragment
- `b06ae44e` fmp4mux: Set fragment header buffer offset to seq number
- `03e9a9f0` fmp4mux: Add support for AC-3 / EAC-3
- `269e469a` fmp4mux: Correctly get ISO 639-2T language codes
- (+ cleanups, comments, FLAC dfLa box)

I checked commits *after* `c3740cd6` on origin/main — no additional bugfixes to the `drain_one_chunk` / late-GOP path. Subsequent commits are tests-only (`8ebdffc6`, `a6b22bc0`), examples (`9e03940b`, `65778b35`), dep bumps (`c09800b7`), a feature (`301c9ce2` — new key-frame chunk mode), and a directory rename (`ec8ab519` — `fmp4` → `isobmff`). So `c3740cd6` is the minimal target that fixes the panic without dragging in unrelated churn.

## Test plan

- [ ] Rebuild the gstreamer base image off `tushar/fix-fmp4-late-gop-panic` (or merged into `cj/update-isofmp4mux`).
- [ ] Update the base image tag in logistics-core's `gpu/Dockerfile`.
- [ ] Run a clip upload against camera `1C:52:A7:01:AE:99` for `2026-05-12T23:21:05.043 → 23:23:05.043` — this is the deterministic repro from the panicking logs (video logs still on disk at `/var/log/orca/orca-video-logs/1c52a701ae99/...`).
- [ ] Confirm no `at_eos` panic in streamer logs across the HIGH → KinesisReady resolution switch.
- [ ] Smoke-test live + clip streaming on a dev NVR, with `header-update-mode=caps` enabled, to confirm the caps-change path is now stable end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)