### PR TITLE
nvenc: log real NVENCSTATUS when NvEncOpenEncodeSessionEx fails

### DIFF
--- a/subprojects/gst-plugins-bad/sys/nvcodec/gstnvbaseenc.c
+++ b/subprojects/gst-plugins-bad/sys/nvcodec/gstnvbaseenc.c
@@ -461,6 +461,8 @@ gst_nv_base_enc_open_encode_session (GstNvBaseEnc * nvenc)
   nv_ret = NvEncOpenEncodeSessionEx (&params, &nvenc->encoder);
 
   if (nv_ret != NV_ENC_SUCCESS) {
+    GST_ERROR_OBJECT (nvenc, "NvEncOpenEncodeSessionEx failed: 0x%x (%s)",
+        (guint) nv_ret, nvenc_status_to_string (nv_ret));
     /* Report error to abort if GST_CUDA_CRITICAL_ERRORS is configured */
     gst_cuda_result (CUDA_ERROR_NO_DEVICE);
     return FALSE;

--- a/subprojects/gst-plugins-bad/sys/nvcodec/gstnvenc.h
+++ b/subprojects/gst-plugins-bad/sys/nvcodec/gstnvenc.h
@@ -93,6 +93,8 @@ gboolean                gst_nvenc_have_set_io_cuda_streams (void);
 gboolean                gst_nvenc_load_library (guint * api_major_ver,
                                                 guint * api_minor_ver);
 
+const gchar *           nvenc_status_to_string (NVENCSTATUS status);
+
 G_END_DECLS
 
 #endif /* __GST_NVENC_H_INCLUDED__ */

--- a/subprojects/gst-plugins-bad/sys/nvcodec/gstnvencobject.cpp
+++ b/subprojects/gst-plugins-bad/sys/nvcodec/gstnvencobject.cpp
@@ -172,7 +172,8 @@ GstNvEncObject::CreateInstance (GstElement * client, GstObject * device,
 
   status = NvEncOpenEncodeSessionEx (params, &session);
   if (!NVENC_IS_SUCCESS (status, nullptr)) {
-    GST_ERROR_OBJECT (device, "NvEncOpenEncodeSessionEx failed");
+    GST_ERROR_OBJECT (device, "NvEncOpenEncodeSessionEx failed: 0x%x (%s)",
+        (guint) status, nvenc_status_to_string (status));
     /* Report error to abort if GST_CUDA_CRITICAL_ERRORS is configured */
     gst_cuda_result (CUDA_ERROR_NO_DEVICE);
     return nullptr;

--- a/subprojects/gst-plugins-bad/sys/nvcodec/gstnvencobject.h
+++ b/subprojects/gst-plugins-bad/sys/nvcodec/gstnvencobject.h
@@ -130,8 +130,6 @@ gst_nv_enc_task_unref (GstNvEncTask * task)
   gst_mini_object_unref (GST_MINI_OBJECT_CAST (task));
 }
 
-const gchar * nvenc_status_to_string (NVENCSTATUS status);
-
 G_END_DECLS
 
 enum GstNvEncCodec


### PR DESCRIPTION
## Problem

Across the NVR fleet, `video_streamer` occasionally aborts with this signature when starting a **new** transcode job (download transcode or live High-res), while all existing pipelines are healthy:

```
W ... [nvenc] WARN   : CUDA call failed: CUDA_ERROR_NO_DEVICE, no CUDA-capable device is detected
E ... [cudautils] ERROR  : Critical error 100, abort
```

The `CUDA_ERROR_NO_DEVICE` is **synthetic**. Both nvenc implementations map *any* `NvEncOpenEncodeSessionEx` failure to `gst_cuda_result (CUDA_ERROR_NO_DEVICE)` purely to trigger the `GST_CUDA_CRITICAL_ERRORS` abort — and discard the real `NVENCSTATUS`:

- `gstnvbaseenc.c` (`nvh264enc`, old impl — logs under `[nvenc]`): logs **nothing** about the real status
- `gstnvencobject.cpp` (new impl — logs under `[nvencoder]`): logs the status only via `NVENC_IS_SUCCESS`, on a separate line

So every incident looks like "the GPU disappeared" when the GPU and CUDA context are actually fine (verified on `coram-watercress-3a894e4b`, which reproduces this every few hours: no Xid errors, no driver/cgroup changes, GPU memory flat, and a fresh process on the same box opens 6 NVENC sessions concurrently). We cannot root-cause the fleet incidents without knowing whether the driver returns `NV_ENC_ERR_OUT_OF_MEMORY`, `NV_ENC_ERR_INVALID_DEVICE`, `NV_ENC_ERR_GENERIC`, etc.

## Change

Log the real status (numeric + enum name) at ERROR level right before the synthetic mapping, in both implementations:

```
E ... [nvenc] ERROR  : NvEncOpenEncodeSessionEx failed: 0xa (NV_ENC_ERR_OUT_OF_MEMORY)   <- example
W ... [nvenc] WARN   : CUDA call failed: CUDA_ERROR_NO_DEVICE, no CUDA-capable device is detected
E ... [cudautils] ERROR  : Critical error 100, abort
```

- `gstnvbaseenc.c`: add `GST_ERROR_OBJECT` with `nvenc_status_to_string (nv_ret)` before the synthetic `gst_cuda_result`
- `gstnvencobject.cpp`: include the status in the existing `NvEncOpenEncodeSessionEx failed` line so one grep catches both impls
- `nvenc_status_to_string()` prototype moves from `gstnvencobject.h` (C++-only header) to `gstnvenc.h`, which both implementations already include; the definition stays in `gstnvencobject.cpp` and keeps C linkage via the `G_BEGIN_DECLS` block

**No behavior change** — the `GST_CUDA_CRITICAL_ERRORS` abort semantics are untouched. ERROR level passes the production `GST_DEBUG=3` threshold, so the status will appear in NVR logs on the next fleet occurrence.

## Verification

Both modified translation units compile cleanly (`-fsyntax-only`, gcc/g++ 11) against the installed `gstreamer-orca` headers in the logistics-core dev container; only pre-existing `nvEncodeAPI.h` deprecation warnings remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
